### PR TITLE
Default connector fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,3 @@
-
-
-
 === Plugin Name ===
 Contributors: eskapism, MarsApril
 Donate link: http://eskapism.se/sida/donate/


### PR DESCRIPTION
This is a minor bugfix for setting default connectors in Wordpress 3.3. Enjoy! :)
