### PR TITLE
Preserves repeatable TinyMCE fields on re-ordering

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -55,7 +55,7 @@ var simple_fields = (function() {
 				id = elms_to_convert[i].id;
 				is_new = (id + '').indexOf('new', 0);
 				is_new = is_new === -1 ? false : true;
-				if (is_new) {
+				if (is_new && typeof(tinyMCE.editors[id]) === 'undefined') {
 					wrap_id = 'wp-'+id+'-wrap';
 					iframe_id = id+"_ifr";
 					iframe_el = jQuery("#"+iframe_id);
@@ -114,24 +114,6 @@ var simple_fields = (function() {
 				dom.removeClass(wrap_id, 'html-active');
 				}
 			}
-		}
-		return false;
-	}
-	
-	function simple_fields_buffer_iframes() {
-		var id, textareas = jQuery("textarea.simple-fields-metabox-field-textarea-tinymce");
-		for (var i=0; i<textareas.length; i++) {
-			id = textareas[i].id;
-			simple_fields_tinymce_iframes[id] = jQuery("#"+id+"_ifr").contents().find('html').html();
-		}
-		return false;
-	}
-	
-	function simple_fields_reset_iframes() {
-		var id, textareas = jQuery("textarea.simple-fields-metabox-field-textarea-tinymce");
-		for (var i=0; i<textareas.length; i++) {
-			id = textareas[i].id;
-			jQuery("#"+id+"_ifr").contents().find('html').html(simple_fields_tinymce_iframes[id]);
 		}
 		return false;
 	}
@@ -643,12 +625,19 @@ var simple_fields = (function() {
 			axis: 'y',
 			handle: ".simple-fields-metabox-field-group-handle",
 			start: function(event, ui) {
-				// buffer, or there will be errors
-				simple_fields_buffer_iframes();
+				ed_move_id = $( ui.item.get(0) ).contents().find('textarea').filter(':first').attr('id');
+				if (ed_move_id && ed_move_id.length > 0) {
+					ed_move_buffer = $('#' + ed_move_id + '_ifr').contents().find('body').html();
+					tinyMCE.execCommand('mceRemoveControl', false, ed_move_id);
+				}
+
 			},
 			stop: function(event, ui) {
-				// reset iframes from buffer
-				simple_fields_reset_iframes();
+				if (ed_move_id && ed_move_id.length > 0) {
+					tinyMCE.execCommand('mceAddControl', false, ed_move_id);
+					$('#' + ed_move_id + '_ifr').contents().find('body').html(ed_move_buffer);
+					tinyMCE.get(ed_move_id).execCommand('mceRepaint');
+				}
 			}
 		});
 


### PR DESCRIPTION
TinyMCE field content buffering doesn't work so well on WP versions newer than 3.4.2. I tested on 3.5, 3.5.1, and nightlies for the past week. The problem could have been introduced through newer versions of TinyMCE, jQuery, jQuery UI or WP code.

My solution follows TinyMCE guidelines for moving editor instances in the DOM. It then applies whatever is in the editor since this often differs from what TinyMCE has in memory; mostly due to WP's own live formatting in the editor.

This also fixes issue #73 ("Repeatable fields and loss of data on update"), a really serious bug if using multiple TinyMCE fields.

Lastly it's important to note that data loss can still occur if user attempts to drag the whole metabox. Options include disabling this action outright or running similar buffering for that 'sortable' event.
